### PR TITLE
Added some battle globals, warnings, and overrides

### DIFF
--- a/output/wh3/all.lua
+++ b/output/wh3/all.lua
@@ -9,9 +9,6 @@ cm = {}
 ---@class campaignui
 CampaignUI = {}
 
----@class battle_manager
-bm = {}
-
 ---@class core
 core = {}
 
@@ -90,3 +87,49 @@ end
 ---@param level integer
 ---@return BUILDING_SCRIPT_INTERFACE
 function episodic_scripting:instantly_set_settlement_primary_slot_level(settlement, level) end
+
+--------Campaign, Battle, and Frontend-------
+
+---@type number
+VOLUME_TYPE_VO = 0
+
+---@type string
+path = ""
+
+-----------------Battle Only-----------------
+
+---@class battle
+local battle = {}
+
+---@class battle_manager : battle
+---@alias bm battle_manager
+battle_manager = {}
+
+---@class battle_manager : battle
+---@field all_scriptunits table<number, script_unit> Indexed by the unique_ui_id. The indexes are not all consecutive. See also battle_manager:get_scriptunit_for_unit
+---@field unit_selection_callback_list table[] This is meant to be used internally by battle_manager:register_unit_selection_callback. But there are circumstances where paperpancake has needed to access this list directly. You can ping paperpancake if you have questions.
+battle_manager = {}
+
+---@class battle_manager
+bm = {}
+
+---@class script_unit
+---@field unit battle_unit
+---@field uc battle_unitcontroller
+script_unit = {}
+
+---@class script_ai_planner
+script_ai_planner = {}
+
+--- @param obj battle_unit|script_unit|script_units|battle_units|battle_army|battle_armies|battle_alliance|table
+--- @param shattered_only? boolean [opt=false]
+--- @param permit_rampaging? boolean [opt=false]
+--- @return boolean
+function is_routing_or_dead(obj, shattered_only, permit_rampaging) end
+
+--- @param obj battle_unit|script_unit|script_units|battle_units|battle_army|battle_armies|battle_alliance|table
+--- @param permit_rampaging? boolean [opt=false]
+--- @return boolean
+function is_shattered_or_dead(obj, permit_rampaging) end
+
+---------------------------------

--- a/override_methods/battle_pancake_param_and_comment_fixes.txt
+++ b/override_methods/battle_pancake_param_and_comment_fixes.txt
@@ -1,0 +1,57 @@
+--- Adds a 3d ping marker model at a specified [x/y/z] position. It is sufficient just to supply the position, but a type can be used to change the model displayed - see the table below for a list of ping types.<br />
+--- List of ping types:<br />
+--- Type NumberType Name
+--- 0MPT_NONE
+--- 1MPT_STANDARD
+--- 2MPT_MOVE
+--- 3MPT_ATTACK
+--- 4MPT_DEFEND
+--- 5MPT_HELP_MOUNTABLE_ARTILLERY
+--- 6MPT_HELP_DISEMBARK
+--- 7MPT_NOTIFICATION
+--- 8MPT_SCRIPT_LOOK_AT
+--- 9MPT_SCRIPT_MOVE_TO
+--- 10MPT_SCRIPT_SELECT
+--- 11MPT_SCRIPT_POINTER
+--- 12MPT_SCRIPT_LOOK_AT_VFX
+--- 13MPT_SCRIPT_MOVE_TO_VFX
+--- 14MPT_SCRIPT_SELECT_VFX
+--- 15MPT_SCRIPT_OBJECTIVE
+--- 16MPT_SCRIPT_BATTLE_TRAP
+--- The waypoint flag can be used to link models together. The rotation flag can be used to specify a rotation for the model - the default is to just fade the camera.
+---@param x number X co-ordinate in metres.
+---@param y number Y co-ordinate (altitude) in metres. This parameter specifies the height above the water plane, so if mis-set the marker can appear under the ground.
+---@param z number Z co-ordinate in metres.
+---@param type number Marker type - see list of valid marker types above.
+---@param is_waypoint boolean Is waypoint.
+---@param rotation number Rotation.
+function battle:add_ping_icon(x, y, z, type, is_waypoint, rotation) end
+
+--- Returns the first commanding battle_unit found in the supplied units collection. Supported collection types are battle_units, battle_army and script_units. If no commanding unit is found then false is returned.
+---@param unit_collection battle_units|battle_army|script_units Unit collection object.
+---@return battle_unit commanding_unit
+function battle_manager:get_general(unit_collection) end
+
+--- Establishes a new watch. A supplied condition function is repeated tested and, when it returns true, a supplied target function is called. A wait period between the condition being met and the target being called must also be specified. A name for the watch may optionally be specified to allow other scripts to cancel it.<br />
+--- The condition must be a function that returns a value - when that value is true (or evaluates to true) then the watch condition is met. The watch then waits the supplied time offset, which is specified in ms as the second parameter, before calling the callback supplied in the third parameter.
+---@param condition function Condition. Must be a function that returns a value. When the returned value is true, or evaluates to true, then the watch condition is met.
+---@param wait_time number Time in ms that the watch waits once the condition is met before triggering the target callback
+---@param target_callback function Target callback
+---@param watch_name string Name for this watch process. Giving a watch a name allows it to be stopped/cancelled with battle_manager:remove_process.
+function battle_manager:watch(condition, wait_time, target_callback, watch_name) end
+
+--- Enqueues a line of advice for delivery to the player. If there is no other advice playing, or nothing is blocking the advisor system, then the advice gets delivered immediately. Otherwise, the supplied advice will be queued and shown at an appropriate time.<br />
+--- The function must be supplied an advice key from the advice_levels/advice_threads tables as its first parameter, unless the advisor entry is set to be debug (see below).
+---@param advice_key string If the advice entry is set to be debug (see third parameter) the text supplied here will instead be shown directly in the advisor window (debug only)
+---@param forced_duration number Forced duration in ms. This is a period that this advice must play for before another item of advice is allowed to start. By default, items of advice will only remain queued while the active advice is actually audibly playing, but by setting a duration the active advice can be held on-screen for longer than the length of its associated soundfile (unless it is closed by the player). This is useful during development to hold advice on-screen when no soundfile yet exists, and also for tutorial scripts which often wish to ensure that an item of advice is shown on-screen for a certain duration.
+---@param debug boolean Sets whether the advice line is debug. If set to true, the text supplied as the first parameter is displayed in the advisor window as-is, without using it as a lookup key in the advice_levels table.
+---@param start_callback function Start callback. If a function is supplied here it is called when the advice is actually played.
+---@param start_callback_wait number Start callback wait period in ms. If a duration is specified it causes a delay between the advice being played and the start callback being called.
+---@param condition function Playback condition. If specified, it compels the advisor system to check this condition immediately before playing the advisor entry to decide whether to actually proceed. This must be supplied as a function block that returns a result. If this result evaluates to true, the advice is played.
+function battle_manager:queue_advisor(advice_key, forced_duration, debug, start_callback, start_callback_wait, condition) end
+
+--- Returns a table containing all spawn zones on the battlefield where the script id of the contained reinforcement line partially match any of the supplied names. The script_id of each spawn zone/reinforcement line pair is checked - should it contain any of the supplied string arguments then that spawn zone is added to the collection to be returned. Partial matches are possible, so a spawn zone with a reinforcement line called something like sz_section_3_rear will match against the argument section_3.<br />
+--- The returned spawn zone collection is a table containing subtables, each of which contains a spawn zone and a count of how many time that spawn zone has had a reinforcement army assigned to it by script. The spawn zone collection can be passed to battle_manager:get_random_spawn_zone_from_collection to get a semi-random spawn zone from the collection.
+---@vararg string Spawn zone names to match, each of which should be a string.
+---@return battle_spawn_zone[] collection List of spawn_zones 
+function battle_manager:get_spawn_zone_collection_by_name(...) end

--- a/override_methods/battle_pancake_warnings.txt
+++ b/override_methods/battle_pancake_warnings.txt
@@ -1,0 +1,96 @@
+-------------------------------------------
+--- WARNING: THIS ONLY ALLOWS ONE HANDLER, OVERWRITING ANY PREVIOUS ONE!!! This is horrible for compatibility unless special care is taken.
+--- Use battle_manager:register_input_handler_callback instead if possible.
+-------------------------------------------
+--- Registers a function (by string name) as a handler for input events. Input events are triggered when the player makes certain inputs. Valid input events are:<br />
+--- "move forward"<br />
+--- "move forward fast"<br />
+--- "move backward"<br />
+--- "move left"<br />
+--- "move right"<br />
+--- "rotate right"<br />
+--- "rotate left"<br />
+--- "move up"<br />
+--- "move down"<br />
+--- "rotate up"<br />
+--- "rotate down"<br />
+--- "edge rotate right"<br />
+--- "edge rotate left"<br />
+--- "edge move left"<br />
+--- "edge move right"<br />
+--- "edge move forward"<br />
+--- "edge move backward"<br />
+--- When an input event occurs, the registered function is called with the relevant input event string as a single argument. Note that the function being registered must have already been declared when register_input_handler is called.<br />
+--- Once registered, an input handler may be unregistered with battle:unregister_input_handler.
+---@param input_handler_function string input handler function
+function battle:register_input_handler(input_handler_function) end
+
+-------------------------------------------
+--- WARNING: THIS ONLY ALLOWS ONE HANDLER, OVERWRITING ANY PREVIOUS ONE!!! This is horrible for compatibility unless special care is taken.
+--- Use battle_manager:register_unit_selection_callback instead if you are listening for the selection of specific units.
+--- If you need a more generic listener that fires whenever *any* unit is selected, you can ping paperpancake for ideas.
+-------------------------------------------
+--- Registers a function (by string name) as a handler for user selection events. These events are triggered when the player selects or deselects units. When such an event occurs, the registered function is called with two arguments - the first being a battle_unit object representing the unit concerned, the second being a boolean flag indicating whether the unit is being selected or deselected. Note that the function being registered must have already been declared when register_unit_selection_handler is called.
+---@param unit_selection_handler_function string input handler function
+function battle:register_unit_selection_handler(unit_selection_handler_function) end
+
+-------------------------------------------
+--- WARNING: THIS ONLY ALLOWS ONE HANDLER, OVERWRITING ANY PREVIOUS ONE!!! This is horrible for compatibility unless special care is taken.
+--- Use battle_manager:register_command_handler_callback instead if possible.
+-------------------------------------------
+--- Registers a function (by string name) as a handler for command events. Command events are triggered when the player (or script) issues certain commands. When such an event occurs, the registered function is called and passed an event object as a single argument. This object provides several methods which can be used to determine information about the issued command. These methods are listed below:<br />
+--- MethodDescription<br />
+--- event:get_name()Returns the string name of the issued command. This is provided for every event type.
+--- event:get_bool1()Returns a boolean value related to the issued command, if any.
+--- event:get_string1()Returns a string value related to the issued command, if any.
+--- event:get_position()Returns a battle_vector related to the issued command, if any.
+--- event:get_unit()Returns a battle_unit related to the issued command, if any.
+--- event:get_building()Returns a battle_building related to the issued command, if any.
+--- Note that each event type only provides methods that are relevant. The list of valid event types, and what methods they provide, are listed here:<br />
+--- Event TypeEvent DescriptionMethod ProvidedMethod Return TypeMethod Description<br />
+--- Group CreatedA group has been createdevent:get_name()stringName of event
+--- Group DestroyedA group has been disbandedevent:get_name()stringName of event
+--- Repair ModeA command to repair a ship has been issuedevent:get_name()stringName of event
+--- <td rowspan=2>Move<td rowspan=2>A movement command has been issuedevent:get_name()stringName of eventevent:get_bool1()booleanIndicates whether the unit is now moving fast/running
+--- Move Orientation WidthA movement command with orientation and width has been issuedevent:get_name()stringName of event
+--- Move Rotation AngleA rotation command has been issuedevent:get_name()stringName of event
+--- <td rowspan=2>Change Speed<td rowspan=2>The speed of a unit has been toggledevent:get_name()stringName of eventevent:get_bool1()booleanIndicates whether the unit is now moving fast/running
+--- <td rowspan=3>Attack Unit<td rowspan=3>A command to attack a unit has been issuedevent:get_name()stringName of eventevent:get_bool1()booleanIndicates whether the unit is now moving fast/runningevent:get_unit()battle_unitReturns the target unit
+--- <td rowspan=2>Change Skirmish<td rowspan=2>Skirmish mode has been toggled on a unitevent:get_name()stringName of eventevent:get_bool1()booleanIndicates whether skirmish mode is now enabled
+--- <td rowspan=2>Change Melee<td rowspan=2>Melee mode has been toggled on a unitevent:get_name()stringName of eventevent:get_bool1()booleanIndicates whether melee mode is now enabled
+--- <td rowspan=2>Change Formation<td rowspan=2>A command to change formation has been issuedevent:get_name()stringName of eventevent:get_string1()stringReturns the name of the formation
+--- <td rowspan=3>Attack Building<td rowspan=3>A command to attack a building has been issuedevent:get_name()stringName of eventevent:get_bool1()booleanIndicates whether the unit is now moving fast/runningevent:get_building()battle_buildingReturns the target building
+--- <td rowspan=3>Climb/Dock Building<td rowspan=3>A command to climb a building has been issuedevent:get_name()stringName of eventevent:get_bool1()booleanIndicates whether the unit is now moving fast/runningevent:get_building()battle_buildingReturns the target building
+--- <td rowspan=2>Special Ability<td rowspan=2>A command to use a special ability has been issuedevent:get_name()stringName of eventevent:get_string1()stringReturns the name of the special ability
+--- <td rowspan=2>Shot Type<td rowspan=2>A command to change shot type has been issuedevent:get_name()stringName of eventevent:get_string1()stringReturns the name of the shot type
+--- Fire At WillFire-at-will mode has been toggled on a unitevent:get_name()stringName of event
+--- <td rowspan=2>Broadside Attack<td rowspan=2>A broadside attack command has been issuedevent:get_name()stringName of eventevent:get_bool1()booleanReturns true if the broadside is on the left side of the ship, false otherwise
+--- <td rowspan=2>Naval Shot Type<td rowspan=2>A command to change the shot type of a ship has been issuedevent:get_name()stringName of eventevent:get_string1()stringReturns the name of the shot type
+--- RamA command to ram a ship has been issuedevent:get_name()stringName of event
+--- <td rowspan=2>Withdraw<td rowspan=2>A command to withdraw a unit has been issuedevent:get_name()stringName of eventevent:get_bool1()booleanIndicates whether the unit is now moving fast/running
+--- HaltA command to halt a unit has been issuedevent:get_name()stringName of event
+--- Double ClickThe double-click UI gesture has been issued for the selected unitsevent:get_name()stringName of event
+--- <td rowspan=3>Entity Hit<td rowspan=3>A unit has been hit by a projectileevent:get_name()stringName of eventevent:get_bool1()booleanIndicates whether artillery fired the projectileevent:get_unit()battle_unitReturns the unit that was hit
+--- <td rowspan=2>Double Click Unit Card<td rowspan=2>A unit card has been double-clicked uponevent:get_name()stringName of eventevent:get_unit()battle_unitReturns the subject unit
+--- <td rowspan=2>Unit Left Battlefield<td rowspan=2>A unit has left the battlefieldevent:get_name()stringName of eventevent:get_unit()battle_unitReturns the subject unit
+--- <td rowspan=2>Battle Results<td rowspan=2>The battle has finished and the results have been issuedevent:get_name()stringName of eventevent:get_bool1()booleanIndicates whether the local alliance won the battle
+--- Note that the function being registered must have already been declared when register_command_handler is called.
+---@param command_handler_function string command handler function
+function battle:register_command_handler(command_handler_function) end
+
+-------------------------------------------
+--- WARNING: THIS ONLY ALLOWS ONE HANDLER, OVERWRITING ANY PREVIOUS ONE!!! This is horrible for compatibility unless special care is taken.
+--- Use battle_manager:register_phase_change_callback instead if possible.
+-------------------------------------------
+--- Registers a function (by string name) as a handler for battle phase changes. Battle phase changes are triggered when the battle moves into various distinct phases, the most important being the deployment and deployment (combat) phases. When a battle phase occurs, the registered function is called and passed the string name of the new battle phase as a single argument. Valid phases are listed below:<br />
+--- Phase NameDescription<br />
+--- StartupThis phase change is triggered after the scripts are loaded.
+--- PrebattleWeatherTriggered after Startup phase.
+--- PrebattleCinematicTriggered after PrebattleWeather phase.
+--- DeploymentDeployment phase, when both alliances get to position their troops prior to combat.
+--- DeployedCombat phase, in which the battle is fought.
+--- VictoryCountdownA victor for the battle has been determined, and the battle is counting down to completion.
+--- CompleteThe battle is completed.
+--- Note that the function being registered must have already been declared when register_unit_selection_handler is called. Furthermore, it is recommended that battle_manager:register_phase_change_callback is used in place of this function.
+---@param function_name string Function name to call when phase change event occurs.
+function battle:register_battle_phase_handler(function_name) end


### PR DESCRIPTION
This pull request does NOT add all globals and overrides in a methodical way.

- `overrides/battle_pancake_warnings` adds some of the battle-related warnings that I've been waving my arms about for years. Note that the end of the warning for register_unit_selection_handler includes an invitation to ping me for ideas.

- `overrides/battle_pancake_param_and_comment_fixes` just has some basic fixes in line with the one from your README.

- I modified `all.lua` with some common things that I've needed for my battle mods so far. (Not comprehensive.)
- (Please double-check my emmylua annotations for `battle_manager` and `bm`. Both of them are `@class battle_manager` but I only had battle_manager extend `battle` explicitly, since I figured that bm would get it transitively. idk.)
- Some of the functions--e.g. `is_routing_or_dead`--that I added in all.lua were from `global.html` but didn't seem to be part of the output/ folder. Is this the right way for me to add these?